### PR TITLE
Added System as an automatically added reference

### DIFF
--- a/src/ElevatorSharp.Web/Controllers/SkyscraperController.cs
+++ b/src/ElevatorSharp.Web/Controllers/SkyscraperController.cs
@@ -105,6 +105,7 @@ namespace ElevatorSharp.Default
             var references = new List<MetadataReference>
             {
                 MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(Assembly.LoadWithPartialName("System").Location),
                 MetadataReference.CreateFromFile(Assembly.LoadWithPartialName("System.Core").Location)
             };
             foreach (var reference in referenceNames)


### PR DESCRIPTION
Added in a reference to System.dll as it's not added unless someone references the base. This might need expanding for people who reference obscure DLLs.